### PR TITLE
baikal: add redirect middleware to make it work with iOS

### DIFF
--- a/charts/baikal/Chart.yaml
+++ b/charts/baikal/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: baikal
 description: The open source CardDAV, CalDAV and WebDAV server
-version: 1.0.0
+version: 1.1.0
 appVersion: 0.9.3-nginx
 kubeVersion: ">=1.16.0-0"
 type: application

--- a/charts/baikal/templates/middleware.yaml
+++ b/charts/baikal/templates/middleware.yaml
@@ -1,0 +1,14 @@
+# For iOS clients we need to redirect /.well-known/carddav and
+# /.well-known/caldav to just /dav.php 
+# See https://homan.ee/en/iphone-calendar-synchronization-ios-settings-for-baikal-caldav
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-card-cal-dav
+  labels:
+    {{- include "librepod.labels" . | nindent 4 }}
+spec:
+  redirectRegex:
+    regex: https://baikal.libre.pod/.well-known/(card|cal)dav
+    replacement: https://baikal.libre.pod/dav.php/
+    permanent: true

--- a/charts/baikal/values.yaml
+++ b/charts/baikal/values.yaml
@@ -17,6 +17,9 @@ ingress:
     enabled: true
     hosts:
       - host: baikal.libre.pod
+    # See templates/middleware.yaml for details.
+    middlewares:
+      - redirect-card-cal-dav
 
 dashboard:
   expose: true


### PR DESCRIPTION
On iOS devices when specifying baikal server for calendar synchronization, iOS hits the https://baikal.libre.pod/.well-known/caldav endpoint which is missing in baikal. To mitigate this we need to implement a middleware that redirect the caller to a proper path.