### PR TITLE
wg-easy: set default MTU to 1280

### DIFF
--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wg-easy
 description: |
   The easiest way to run WireGuard VPN + Web-based Admin UI.
-version: 1.3.1
+version: 1.4.0
 appVersion: "7"
 kubeVersion: ">=1.16.0-0"
 type: application

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -17,6 +17,8 @@ env:
   WG_HOST: '{{ default .Values.hostIP .Values.wgHost }}'
   WG_PORT: '{{ default 51820 .Values.wgPort }}'
   WG_DEFAULT_ADDRESS: 10.6.0.x
+  # WireGuard interface MTU for devices. 1280 is a safe bet for most networks
+  WG_MTU: 1280
   # Host should provide DNS service via Pi-Hole
   WG_DEFAULT_DNS: '{{ .Values.hostIP }}'
 


### PR DESCRIPTION
With the default value of 1420 I had problems opening duckduckgo and github websites.