### PR TITLE
librepod-lib: use tpl function for ingressroute annotations

### DIFF
--- a/charts/librepod/Chart.yaml
+++ b/charts/librepod/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: librepod
 description: A Helm library chart for LibrePod specific Kubernetes clusters
 type: library
-version: 1.2.0
+version: 1.2.1

--- a/charts/librepod/templates/lib/classes/_ingressroute.yaml
+++ b/charts/librepod/templates/lib/classes/_ingressroute.yaml
@@ -32,10 +32,8 @@ metadata:
   name: {{ $ingressName }}
   labels:
     {{- include "librepod.labels" . | nindent 4 }}
-  {{- with $values.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- tpl (toYaml $values.annotations) . | nindent 4 }}
 spec:
   entryPoints:
     - web


### PR DESCRIPTION
This allows using helm templates in values.yaml file when defining ingress annotations